### PR TITLE
set not need file generation false

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,12 @@ module Protospace
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.generators do |g|
+      g.helper false
+      g.assets false
+      g.test_framework false
+    end
   end
 end
 


### PR DESCRIPTION
# WHAT
- config/application.rbに  

`config.generators do |g| 
  g.helper false 
  g.assets false 
  g.test_framework false
end`

を追記
# WHY
- rails gの時、不要なファイルを作らないようにするため
