### PR TITLE
Import js

### DIFF
--- a/app/assets/javascripts/image_preview.js
+++ b/app/assets/javascripts/image_preview.js
@@ -1,0 +1,24 @@
+$(window).on("click", function(){
+  $(".js-image-preview").each(function() {
+    var prev = $(this)
+    image = prev.find('input[type=file]');
+    image.change(function(){
+      var file = this.files[0]
+      if (!this.files.length){
+        return;
+      }
+      if (!file.type.match('image.*')) {
+        window.alert('This file is not available!');
+        return;
+      }
+      fileReader = new FileReader();
+      fileReader.readAsDataURL(file);
+      fileReader.onload = function(){
+        prev.css({
+          'background-image': 'url(' + fileReader.result + ')',
+          'background-size' : 'cover'
+        });
+      };
+      });
+    });
+  });

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  mount_uploader :image, UserImageUploader
   has_many :prototypes
   has_many :likes
   has_many :comments

--- a/app/uploaders/user_image_uploader.rb
+++ b/app/uploaders/user_image_uploader.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+class UserImageUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process :scale => [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process :resize_to_fit => [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_white_list
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,7 +8,7 @@
           .user-name_image.row
             .user-name.col-md-10
               = f.text_field :name, placeholder: "Username"
-            .user-image.col-md-2
+            .user-image.col-md-2.js-image-preview
               %button.btn.btn-primary Add image
               = f.file_field :image
           = f.email_field :email, placeholder: "E-Mail", class: "user-email"

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -1,4 +1,4 @@
-.container.proto-new{action: ""}
+.container.proto-new{ action: "" }
   = form_for @prototype do |f|
     = f.hidden_field :user_id, value: current_user.id
     .col-md-8.col-md-offset-2
@@ -7,15 +7,15 @@
           = f.text_field :title, placeholder: "Title"
       .row
         .col-md-12
-          .cover-image-upload.js-preview-image
-            = f.fields_for :proto_thumbnails, @main_image do |thumbnail|
+          .cover-image-upload.js-image-preview
+            = f.fields_for :prototype_thumbnails, @main_image do |thumbnail|
               = thumbnail.file_field :image
               = thumbnail.hidden_field :state, value: "main"
         .col-md-12
           %ul.proto-sub-list.list-group
             - 3.times do
               %li.list-group-item.col-md-4
-                .image-upload
+                .image-upload.js-image-preview
                   = f.fields_for :prototype_thumbnails, @sub_images do |thumbnail|
                     = thumbnail.file_field :image
                     = thumbnail.hidden_field :state, value: "sub"

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -7,7 +7,7 @@
           = f.text_field :title, placeholder: "Title"
       .row
         .col-md-12
-          .cover-image-upload
+          .cover-image-upload.js-image-preview
             = f.fields_for :prototype_thumbnails, @main_image do |thumbnail|
               = thumbnail.file_field :image
               = thumbnail.hidden_field :state, value: "main"
@@ -15,7 +15,7 @@
           %ul.proto-sub-list.list-group
             - 3.times do
               %li.list-group-item.col-md-4
-                .image-upload
+                .image-upload.js-image-preview
                   = f.fields_for :prototype_thumbnails, @sub_images do |thumbnail|
                     = thumbnail.file_field :image
                     = thumbnail.hidden_field :state, value: "sub"

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -22,7 +22,7 @@
       %ul.proto-sub-list.list-group
         - @prototype.prototype_thumbnails.sub.each do |sub|
           %li.list-group-item
-            = image_tag sub_image.image, class: 'img-responsive'
+            = image_tag sub.image, class: 'img-responsive'
   .row.proto-description
     .col-md-3
       %h4 Catch Copy

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -7,9 +7,9 @@
           .user-name_image.row
             .user-name.col-md-10
               = f.text_field :name, placeholder: "Username"
-            .user-image.col-md-2
+            .user-image.col-md-2.js-image-preview{ style: "background-image: url(#{ current_user.image });" }
               %button.btn.btn-primary Change image
-              = f.text_field :image
+              = f.file_field :image
           .user-name.col-md-10
           = f.email_field :email, placeholder: "E-Mail"
         .col-md-12

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -2,8 +2,7 @@
   %header.user-nav
     .media
       .media-left
-        = link_to '#'
-        %img.media-object{ alt: "64x64", data_holder_rendered: "true", data_src: "holder.js/64x64", style: "width: 64px; height: 64px;"}/
+        = image_tag @user.image, class:"media-object", alt:"64x64", data: {holder:{rendered: true}}, data: {src: "holder.js/64x64"}, size: "64x64"
       .media-body
         %h4#top-aligned-media.media-heading
           Top aligned media
@@ -28,20 +27,4 @@
 .text-center
   %ul.pagination
     %li.disabled
-      = link_to '#', aria: {label: "Previous"} do
-        %span{"aria-hidden" => "true"} «}
-    %li.active
-      = link_to "#" do
-        1
-        %span.sr-only (current)
-    %li
-      = link_to '2', '#'
-    %li
-      = link_to '3', '#'
-    %li
-      = link_to '4', '#'
-    %li
-      = link_to '5', '#'
-    %li
-      = link_to '#', aria: {label: "Next"} do
-        %span{aria: { hidden: true}} »
+      = paginate(@prototypes)


### PR DESCRIPTION
# WHAT
- Prototypeの新規投稿時
- Prototypeの編集時
- ユーザーの新規登録時
- ユーザー情報の編集時
# WHY

投稿・編集時に、どの画像を選択しているか分かるようにするため
# Commit
- image_previewのJS追加
- 画像を投稿・編集するビューのクラスにJSのクラスを追加
# Modify
- ユーザーの投稿一覧の名前からマイページに飛ぶように実装
- ユーザーページのページネーション追加
- prototypeのサブの画像が表示されてなかったのを修正
